### PR TITLE
hugo/fogros2: Changed to generic ami image

### DIFF
--- a/fogros2/fogros2/aws.py
+++ b/fogros2/fogros2/aws.py
@@ -172,10 +172,10 @@ class RemoteMachine(CloudInstance):
 class AWS(CloudInstance):
     def __init__(
             self,
+            ami_image,
             region="us-west-1",
             ec2_instance_type="t2.micro",
             disk_size = 30,
-            ami_image = "ami-01f87c43e618bf8f0",
             **kwargs
     ):
         super().__init__(**kwargs)

--- a/fogros2_examples/launch/talker.launch.py
+++ b/fogros2_examples/launch/talker.launch.py
@@ -16,7 +16,7 @@ import fogros2
 
 def generate_launch_description():
     ld = FogROSLaunchDescription()
-    machine1 = fogros2.AWS(region="us-west-1", ec2_instance_type="t2.micro")
+    machine1 = fogros2.AWS(region="us-west-1", ec2_instance_type="t2.medium", ami="ami-01f87c43e618bf8f0")    
 
     talker_node = Node(
         package="fogros2_examples", executable="listener", output="screen")


### PR DESCRIPTION
Changed the existing ami image which contains a working ros_rolling installation and other dependencies to a generic ami image. Implemented automated process of installing ros_rolling and dependencies needed in the other automated processes ran after the installation.