### PR TITLE
potential fix: vpn setup order when wg0 does not exist

### DIFF
--- a/fogros2_launch/launch/launch/fogros_launch_description.py
+++ b/fogros2_launch/launch/launch/fogros_launch_description.py
@@ -108,9 +108,10 @@ class VPN:
     def start_robot_vpn(self):
         # Copy /tmp/fogros-local.conf to /etc/wireguard/wg0.conf locally.
         # TODO: This needs root. Move this to a separate script with setuid.
-        os.system("sudo wg-quick down wg0")
+
         os.system("sudo cp /tmp/fogros-local.conf /etc/wireguard/wg0.conf")
         os.system("sudo chmod 600 /etc/wireguard/wg0.conf")
+        os.system("sudo wg-quick down wg0")
         os.system("sudo wg-quick up wg0")
 
 


### PR DESCRIPTION
I repeated the steps that @vmayoral mentioned. I had the same problem whenever I start fogros container the first time. 

Then my theory is that if the VPN's wg0 interface exists, but `/etc/wireguard/wg0` file does not exist(because the container is new), then the interface is not deleted and restarted. Then the setup does not succeed. 