### PR TITLE
Fix Docker bugs, make remote distro depend on local distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,15 @@ ARG DISTRO=rolling
 FROM ubuntu:jammy
 
 ARG DISTRO
+ENV TZ=America/Vancouver
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt update && apt install -y curl gnupg2 lsb-release sudo && \
     curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
     
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu jammy main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y ros-rolling-desktop
-
-RUN apt update && sudo apt install -y \
+RUN apt update && DEBIAN_FRONTEND=noninteractive sudo apt install -y \
+  ros-${DISTRO}-desktop \
   build-essential \
   cmake \
   python3-colcon-common-extensions \
@@ -24,27 +25,8 @@ RUN apt update && sudo apt install -y \
   ssh
 
 RUN rm -rf /var/lib/apt/lists/*
- 
-# install some pip packages needed for testing
-RUN python3 -m pip install --no-cache-dir -U \
-  argcomplete \
-  flake8 \
-  flake8-blind-except \
-  flake8-builtins \
-  flake8-class-newline \
-  flake8-comprehensions \
-  flake8-deprecated \
-  flake8-docstrings \
-  flake8-import-order \
-  flake8-quotes \
-  pytest-repeat \
-  pytest-rerunfailures \
-  pytest \
-  pytest-cov \
-  pytest-runner 
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-
 RUN unzip awscliv2.zip && rm awscliv2.zip
 RUN ./aws/install
 RUN python3 -m pip install --no-cache-dir -U boto3 paramiko scp wgconfig

--- a/fogros2_examples/launch/talker.aws.launch.py
+++ b/fogros2_examples/launch/talker.aws.launch.py
@@ -37,8 +37,8 @@ def generate_launch_description():
     ld = FogROSLaunchDescription()
     machine1 = AWS(region="us-west-1", ec2_instance_type="t2.micro", ami_image=ami_image())
 
-    talker_node = Node(package="fogros2_examples", executable="listener", output="screen")
-    listener_node = CloudNode(
+    listener_node = Node(package="fogros2_examples", executable="listener", output="screen")
+    talker_node = CloudNode(
         package="fogros2_examples", executable="talker", output="screen", machine=machine1
     )
     ld.add_action(talker_node)

--- a/fogros2_examples/launch/talker.local.launch.py
+++ b/fogros2_examples/launch/talker.local.launch.py
@@ -19,8 +19,8 @@ def generate_launch_description():
     """
     ld = LaunchDescription()
 
-    talker_node = Node(package="fogros2_examples", executable="listener", output="screen")
-    listener_node = Node(
+    listener_node = Node(package="fogros2_examples", executable="listener", output="screen")
+    talker_node = Node(
         package="fogros2_examples", executable="talker", output="screen"
     )
     ld.add_action(talker_node)

--- a/ros_entrypoint.sh
+++ b/ros_entrypoint.sh
@@ -6,7 +6,8 @@ source /opt/ros/$ROS_DISTRO/setup.bash
 source $ROS_WS/install/setup.bash
 
 # work with CycloneDDS DDS implementation
+ver=$(lsb_release -a 2>&1 | awk 'FNR==4 {gsub(/\./, ""); print $2}')
 export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-export CYCLONEDDS_URI=file://$(pwd)/install/share/fogros2/configs/cyclonedds.xml
+export CYCLONEDDS_URI=file://$(pwd)/install/share/fogros2/configs/cyclonedds.ubuntu.$ver.xml
 
 exec "$@"


### PR DESCRIPTION
- Fixes #52 by updating `ros_entrypoint.sh` to use the correct path for CYCLONEDDS_URI
- Fixes #48 by replacing `rolling` with a ros distro variable in `cloud_node.py`
- Cleans up the current Dockerfile by removing unnecessary installs