### PR TITLE
CLI error checking and interpretable error messaging

### DIFF
--- a/fogros2/fogros2/verb/delete.py
+++ b/fogros2/fogros2/verb/delete.py
@@ -1,54 +1,66 @@
-import json
 import os
 import shutil
-import boto3
-import botocore
 
+import boto3
+from botocore.exceptions import NoRegionError
+from fogros2.util import instance_dir
 from ros2cli.verb import VerbExtension
 
-from fogros2 import AWS
-from fogros2.util import instance_dir
-from botocore.exceptions import ClientError
 
 class DeleteVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
         parser.add_argument(
-            "--all", "-A", action="store_true", default=False, help="Delete All existing FogROS instances")
-        parser.add_argument("--region", nargs='*', help="Set AWS region.  Overrides config/env settings.")
-        parser.add_argument("--name", "-n", type=str, nargs=1, help="Select FogROS instance name to delete")
-        parser.add_argument("--dry-run", action='store_true', help="Show what would happen, but do not execute")
+            "name", type=str, nargs=1, help="FogROS instance name to delete, or 'all' to delete all instances"
+        )
+        parser.add_argument("--region", nargs="*", help="Set AWS region (overrides config/env settings)")
+        parser.add_argument("--dry-run", action="store_true", help="Show what would happen, but do not execute")
 
     def query_region(self, region, args):
-        client = boto3.client("ec2", region)
+        try:
+            client = boto3.client("ec2", region)
+        except NoRegionError:
+            raise RuntimeError("AWS is not configured! Please run `aws configure` first.")
 
-        if args.all == True:
+        if args.name == "all":
             # Any instance with a FogROS2-Name tag.
-            tag_filter = {"Name":"tag-key", "Values":["FogROS2-Name"]}
+            tag_filter = {"Name": "tag-key", "Values": ["FogROS2-Name"]}
         else:
             # only instances with specific name tag.
-            tag_filter = {"Name":"tag:FogROS2-Name", "Values":args.name}
-        
+            tag_filter = {"Name": "tag:FogROS2-Name", "Values": args.name}
+
         ec2_instances = client.describe_instances(
-            Filters=[{"Name":"instance.group-name", "Values":["FOGROS2_SECURITY_GROUP"]},
-                     tag_filter])
+            Filters=[{"Name": "instance.group-name", "Values": ["FOGROS2_SECURITY_GROUP"]}, tag_filter]
+        )
+
+        if len(ec2_instances["Reservations"]) == 0:
+            print("No EC2 instances found with the specified name; check list to be sure name is correct!")
 
         return [client, ec2_instances]
 
     def delete_instances(self, client, ec2_instances, dry_run):
         delete_count = 0
-        for res in ec2_instances['Reservations']:
-            for inst in res['Instances']:
-                tag_map = { t['Key']:t['Value'] for t in inst['Tags'] } if 'Tags' in inst else {}
+        for res in ec2_instances["Reservations"]:
+            for inst in res["Instances"]:
+                tag_map = {t["Key"]: t["Value"] for t in inst["Tags"]} if "Tags" in inst else {}
                 print(f"Deleting {tag_map.get('FogROS2-Name', '(unknown)')} {inst['InstanceId']}")
-                # self.delete_instance(tag_map.get('FogROS2-Name'), region, instance['InstanceId'])
                 print(f"    terminating instance {inst['InstanceId']}")
                 if not dry_run:
-                    response = client.terminate_instances(InstanceIds=[inst['InstanceId']])
+                    response = client.terminate_instances(InstanceIds=[inst["InstanceId"]])
+                    if (
+                        "TerminatingInstances" not in response
+                        or response["TerminatingInstances"]["InstanceId"] != inst["InstanceId"]
+                    ):
+                        raise RuntimeError(f"Could not terminate instance {inst['InstanceId']}!")
                 print(f"    deleting key pair {inst['KeyName']}")
                 if not dry_run:
-                    response = client.delete_key_pair(KeyName=inst['KeyName'])
-                if 'FogROS2-Name' in tag_map:
-                    inst_dir = os.path.join(instance_dir(), tag_map['FogROS2-Name'])
+                    response = client.delete_key_pair(KeyName=inst["KeyName"])
+                    if (
+                        "TerminatingInstances" not in response
+                        or response["TerminatingInstances"]["InstanceId"] != inst["InstanceId"]
+                    ):
+                        raise RuntimeError(f"Could not delete key pair {inst['KeyName']}!")
+                if "FogROS2-Name" in tag_map:
+                    inst_dir = os.path.join(instance_dir(), tag_map["FogROS2-Name"])
                     if os.path.exists(inst_dir):
                         print(f"    removing instance data {inst_dir}")
                         if not dry_run:
@@ -61,19 +73,20 @@ class DeleteVerb(VerbExtension):
     def main(self, *, args):
         regions = args.region
         if regions is None or len(regions) == 0:
-            regions = [ None ]
+            regions = [None]
         elif "*" in regions or "all" in regions:
             client = boto3.client("ec2")
             response = client.describe_regions()
-            regions = [ r["RegionName"] for r in response["Regions"] ]
+            regions = [r["RegionName"] for r in response["Regions"]]
 
         if len(regions) == 1:
             delete_count = self.delete_instances(*self.query_region(regions[0], args), args.dry_run)
         else:
             from concurrent.futures import ThreadPoolExecutor, as_completed
+
             with ThreadPoolExecutor(max_workers=len(regions)) as executor:
-                futures = [ executor.submit(self.query_region, r, args) for r in regions ]
-                delete_count = sum([ self.delete_instances(*f.result(), args.dry_run) for f in futures ])
+                futures = [executor.submit(self.query_region, r, args) for r in regions]
+                delete_count = sum([self.delete_instances(*f.result(), args.dry_run) for f in futures])
 
         if delete_count == 0:
-            print("No instances deleted.")
+            print("No instances deleted")

--- a/fogros2/fogros2/verb/image.py
+++ b/fogros2/fogros2/verb/image.py
@@ -1,8 +1,9 @@
 import json
 import os
+
 import boto3
-from ros2cli.verb import VerbExtension
 from fogros2.util import work_dir
+from ros2cli.verb import VerbExtension
 
 
 class ImageVerb(VerbExtension):
@@ -16,7 +17,7 @@ class ImageVerb(VerbExtension):
         info_path = os.path.join(pwd, "info")
         if not os.path.isfile(info_path):
             print("the info file does not exist, likely that the instance is not fully initialized")
-            return 
+            return
         with open(info_path) as f:
             instance_info = json.loads(f.read())
 
@@ -25,7 +26,7 @@ class ImageVerb(VerbExtension):
 
             image_name = "AWS_FogROS_image_" + instance
             client = boto3.client("ec2", region_name=instance_info["ec2_region"])
-            client.create_image(InstanceId=instance_info["ec2_instance_id"],  Name=image_name)
+            client.create_image(InstanceId=instance_info["ec2_instance_id"], Name=image_name)
 
             images = client.describe_images(Owners=["self"])["Images"]
             for image in images:

--- a/fogros2/fogros2/verb/list.py
+++ b/fogros2/fogros2/verb/list.py
@@ -1,80 +1,77 @@
-import json
-import os
 import boto3
-import botocore
-
+from botocore.exceptions import NoRegionError
 from ros2cli.verb import VerbExtension
-from fogros2.util import instance_dir
-from botocore.exceptions import ClientError
+
 
 class ListVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
-        parser.add_argument(
-            "--region", nargs='*', help="Set AWS region.  Overrides config/env settings.")
+        parser.add_argument("--region", nargs="*", help="Set AWS region (overrides config/env settings)")
 
     def query_region(self, region):
-        # print(f"Scanning {region}")
-        client = boto3.client("ec2", region)
-        #response = client.describe_vpcs()
-        #vpc_id = response.get("Vpcs", [{}])[0].get("VpcId", "")
+        try:
+            client = boto3.client("ec2", region)
+        except NoRegionError:
+            raise RuntimeError("AWS is not configured! Please run `aws configure` first.")
 
         ec2_instances = client.describe_instances(
-            Filters=[{"Name":"instance.group-name", "Values":["FOGROS2_SECURITY_GROUP"]},
-                     {"Name":"tag-key", "Values":["FogROS2-Name"]}])
+            Filters=[
+                {"Name": "instance.group-name", "Values": ["FOGROS2_SECURITY_GROUP"]},
+                {"Name": "tag-key", "Values": ["FogROS2-Name"]},
+            ]
+        )
 
         # For each instance, we also look up the block device mapping
         # to get the disk size.
         for res in ec2_instances["Reservations"]:
             for inst in res["Instances"]:
                 volumes = client.describe_volumes(
-                    VolumeIds = [ m['Ebs']['VolumeId'] for m in inst['BlockDeviceMappings'] ])
+                    VolumeIds=[m["Ebs"]["VolumeId"] for m in inst["BlockDeviceMappings"]]
+                )
                 # Update the ec2_instances structure to include the
                 # block device info.
-                for i in range(len(volumes['Volumes'])):
+                for i in range(len(volumes["Volumes"])):
                     # Attachments duplicates info we already have, so
                     # delete it.  Not really necessary, but it cleans
                     # things up when debugging.
-                    del volumes['Volumes'][i]['Attachments']
-                    inst['BlockDeviceMappings'][i]['Ebs']['VolumeInfo'] = volumes['Volumes'][i]
-                    
+                    del volumes["Volumes"][i]["Attachments"]
+                    inst["BlockDeviceMappings"][i]["Ebs"]["VolumeInfo"] = volumes["Volumes"][i]
+
         return [region, ec2_instances]
 
     def print_region_info(self, region, ec2_instances):
-        # import pprint
-        # pp = pprint.PrettyPrinter(indent=4)
+        if len(ec2_instances["Reservations"]) == 0:
+            print("No FogROS instances found")
         for res in ec2_instances["Reservations"]:
             for inst in res["Instances"]:
-                # pp.pprint(inst)
-                tag_map = { t['Key']:t['Value'] for t in inst['Tags'] } if 'Tags' in inst else {}
+                tag_map = {t["Key"]: t["Value"] for t in inst["Tags"]} if "Tags" in inst else {}
                 print(f"====== {tag_map.get('FogROS2-Name', '(unknown)')} ======")
                 print("cloud_service_provider: AWS")
                 print(f"ec2_region: {region}")
                 print(f"ec2_instance_type: {inst.get('InstanceType', '(unknown)')}")
                 print(f"ec2_instance_id: {inst.get('InstanceId', '(unknown)')}")
                 print(f"public_ip: {inst.get('PublicIpAddress', '(none)')}")
-                # for ni in inst['NetworkInterfaces']:
-                #     print(f"    public_ip: {ni['Association']['PublicIp']}")
                 print(f"ssh_key: {inst.get('KeyName', '(unknown)')}")
-                for bdm in inst['BlockDeviceMappings']:
-                    if 'Ebs' in bdm and 'VolumeInfo' in bdm['Ebs']:
+                for bdm in inst["BlockDeviceMappings"]:
+                    if "Ebs" in bdm and "VolumeInfo" in bdm["Ebs"]:
                         print(f"disk_size: {bdm['Ebs']['VolumeInfo']['Size']}")
                 print(f"aws_ami_image: {inst.get('ImageId', '(unknown)')}")
                 print(f"state: {inst.get('State', {'Name':'(unknown)'})['Name']}")
-        
+
     def main(self, *, args):
         regions = args.region
         if regions is None or len(regions) == 0:
-            regions = [ None ] # use default (should we default to "all")
+            regions = [None]  # use default (should we default to "all")
         elif "*" in regions or "all" in regions:
             client = boto3.client("ec2")
             response = client.describe_regions()
-            regions = [ r["RegionName"] for r in response["Regions"] ]
-            
+            regions = [r["RegionName"] for r in response["Regions"]]
+
         if len(regions) == 1:
             self.print_region_info(*self.query_region(regions[0]))
         else:
             from concurrent.futures import ThreadPoolExecutor, as_completed
+
             with ThreadPoolExecutor(max_workers=len(regions)) as executor:
-                futures = [ executor.submit(self.query_region, r) for r in regions ]
+                futures = [executor.submit(self.query_region, r) for r in regions]
                 for f in as_completed(futures):
                     self.print_region_info(*f.result())

--- a/fogros2/fogros2/verb/ssh.py
+++ b/fogros2/fogros2/verb/ssh.py
@@ -1,58 +1,65 @@
-import json
 import os
-import boto3
-import botocore
 
-from ros2cli.verb import VerbExtension
+import boto3
+from botocore.exceptions import NoRegionError
 from fogros2.util import instance_dir
-from botocore.exceptions import ClientError
+from ros2cli.verb import VerbExtension
+
 
 class SSHVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):
-        parser.add_argument("--name", "-n", type=str, nargs=1, help="Select FogROS instance name to connect")
-        parser.add_argument("--region", nargs='*', help="Set AWS region.  Overrides config/env settings.")
+        parser.add_argument("name", type=str, nargs=1, help="FogROS instance name to connect to")
+        parser.add_argument("--region", nargs="*", help="Set AWS region (overrides config/env settings)")
         parser.add_argument(
             "--user", "-u", type=str, nargs="?", default="ubuntu", help="User name of the remote SSH instance"
         )
 
     def query_region(self, region, name):
-        client = boto3.client("ec2", region)
+        try:
+            client = boto3.client("ec2", region)
+        except NoRegionError:
+            raise RuntimeError("AWS is not configured! Please run `aws configure` first.")
+
         ec2_instances = client.describe_instances(
-            Filters=[{"Name":"instance.group-name", "Values":["FOGROS2_SECURITY_GROUP"]},
-                     {"Name":"tag:FogROS2-Name", "Values":name}])
+            Filters=[
+                {"Name": "instance.group-name", "Values": ["FOGROS2_SECURITY_GROUP"]},
+                {"Name": "tag:FogROS2-Name", "Values": name},
+            ]
+        )
         return ec2_instances
-        
+
     def main(self, *, args):
         regions = args.region
 
         if regions is None or len(regions) == 0:
-            regions = [ None ]
+            regions = [None]
         elif "*" in regions or "all" in regions:
             client = boto3.client("ec2")
             response = client.describe_regions()
-            regions = [ r["RegionName"] for r in response["Regions"] ]
-            
+            regions = [r["RegionName"] for r in response["Regions"]]
+
         if len(regions) == 1:
-            instances = [ self.query_region(regions[0], args.name) ]
+            instances = [self.query_region(regions[0], args.name)]
         else:
             from concurrent.futures import ThreadPoolExecutor, as_completed
+
             with ThreadPoolExecutor(max_workers=len(regions)) as executor:
-                futures = [ executor.submit(self.query_region, r, args.name) for r in regions ]
-                instances = [ f.result() for f in as_completed(futures) ]
+                futures = [executor.submit(self.query_region, r, args.name) for r in regions]
+                instances = [f.result() for f in as_completed(futures)]
 
         for ec2_instances in instances:
-            for res in ec2_instances['Reservations']:
-                for inst in res['Instances']:
-                    tag_map = { t['Key']:t['Value'] for t in inst['Tags'] } if 'Tags' in inst else {}
-                    name = tag_map['FogROS2-Name']
-                    key_name = inst['KeyName']
+            for res in ec2_instances["Reservations"]:
+                for inst in res["Instances"]:
+                    tag_map = {t["Key"]: t["Value"] for t in inst["Tags"]} if "Tags" in inst else {}
+                    name = tag_map["FogROS2-Name"]
+                    key_name = inst["KeyName"]
                     key_path = os.path.join(instance_dir(), name, key_name + ".pem")
-                    if 'PublicIpAddress' not in inst:
+                    if "PublicIpAddress" not in inst:
                         print(f"Warning: matching instance does not have a public IP address")
                         continue
-                    public_ip = inst['PublicIpAddress']
+                    public_ip = inst["PublicIpAddress"]
                     os.execvp("ssh", ("ssh", "-i", key_path, f"{args.user}@{public_ip}"))
 
         # Since execvp replaces the current process, if here, we
         # haven't found a matching instance.
-        print("No matching instance found.")
+        print("No matching instance found")


### PR DESCRIPTION
- Fixes #50 (removes `--name` option in favor of a required argument -- can be `all` for `delete` -- and shifts burden of validation to `argparse`)
- Fixes #51 (adds error handling to check if AWS config is setup already)
- Formatting of `verb` directory 