### PR TITLE
added check for environment variables

### DIFF
--- a/fogros2/fogros2/aws.py
+++ b/fogros2/fogros2/aws.py
@@ -35,6 +35,9 @@ class CloudInstance(abc.ABC):
         working_dir_base=instance_dir(),
         vis=False,
     ):
+        if not ("RMW_IMPLEMENTATION" or "CYCLONEDDS_URI") in os.environ:
+            raise Exception("RMW_IMPLEMENTATION or CYCLONEDDS_URI environment variables not set.")
+        
         # others
         self.logger = logging.get_logger(__name__)
 

--- a/fogros2/fogros2/aws.py
+++ b/fogros2/fogros2/aws.py
@@ -35,9 +35,9 @@ class CloudInstance(abc.ABC):
         working_dir_base=instance_dir(),
         vis=False,
     ):
-        if not ("RMW_IMPLEMENTATION" or "CYCLONEDDS_URI") in os.environ:
-            raise Exception("RMW_IMPLEMENTATION or CYCLONEDDS_URI environment variables not set.")
-        
+        assert "RMW_IMPLEMENTATION" in os.environ, "RMW_IMPLEMENTATION environment variable not set"
+        assert "CYCLONEDDS_URI" in os.environ, "CYCLONEDDS_URI environment variable not set"
+            
         # others
         self.logger = logging.get_logger(__name__)
 


### PR DESCRIPTION
Added check for environment variables in the init so that it raises an exception when the RMW_IMPLEMENTATION or CYCLONEDDS_URI environment variables are not set before running launch files.