### PR TITLE
dev: format changed files on push

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, E501

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.2.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: mixed-line-ending
+  - id: check-json
+  - id: check-toml
+  - id: check-yaml
+  - id: check-merge-conflict
+  - id: debug-statements
+  - id: name-tests-test
+- repo: local
+  # run all of these hooks from the Poetry versions
+  hooks:
+  - id: isort
+    name: isort
+    entry: python3 -m isort
+    language: system
+    types: [python]
+    require_serial: true
+  - id: black
+    name: black
+    entry: python3 -m black
+    language: system
+    types: [python]
+    require_serial: true
+  - id: flake8
+    name: flake8
+    entry: python3 -m flake8
+    language: system
+    types: [python]
+    require_serial: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+## Technical Notes
+
+Please install our pre-commit scripts to ensure your code is properly formatted.
+
+```bash
+python3 -m pip install pre-commit black flake8 isort
+pre-commit install
+```

--- a/fogros2/requirements-dev.txt
+++ b/fogros2/requirements-dev.txt
@@ -1,0 +1,3 @@
+black
+flake8
+isort


### PR DESCRIPTION
🚨 This requires you to have `black`, `flake8`, and `isort` installed into your venv's `python3`. 🚨

In the future, we should switch to [colocon-poetry-ros](https://github.com/UrbanMachine/colcon-poetry-ros) for better dependency management. This way we can have one build system handle our development dependencies (hopefully soon to include mypy) and the ROS dependencies.

## Usage

See the `CONTRIBUTING.md` file in this pull request. All users of this repository will have to run these commands to install the pre-commit rules.