### PR TITLE
Datacenter selection

### DIFF
--- a/fogros2/fogros2/aws_cloud_instance.py
+++ b/fogros2/fogros2/aws_cloud_instance.py
@@ -35,6 +35,7 @@ import json
 import os
 import requests
 from math import radians, cos, sin, asin, sqrt
+from ping3 import ping
 
 import boto3
 from botocore.exceptions import ClientError
@@ -155,13 +156,24 @@ class AWSCloudInstance(CloudInstance):
         self.generate_key_pair()
         self.create_ec2_instance()
         self.info(flush_to_disk=True)
-        self.connect()
-        self.install_ros()
-        self.install_cloud_dependencies()
-        self.install_colcon()
-        self.push_ros_workspace()
-        self.info(flush_to_disk=True)
-        self._is_created = True
+        self.test_latency()
+        # self.connect()
+        # self.install_ros()
+        # self.install_cloud_dependencies()
+        # self.install_colcon()
+        # self.push_ros_workspace()
+        # self.info(flush_to_disk=True)
+        # self._is_created = True
+
+    def test_latency(self):
+        ping_sum = 0
+        count = 0
+        while count < 100:
+            latency = ping(self._ip)
+            if latency:
+                ping_sum += latency
+                count += 1
+        print(ping_sum / count)
 
     def info(self, flush_to_disk=True):
         info_dict = super().info(flush_to_disk)

--- a/fogros2/fogros2/aws_cloud_instance.py
+++ b/fogros2/fogros2/aws_cloud_instance.py
@@ -33,7 +33,6 @@
 
 import json
 import os
-from ping3 import ping
 
 import boto3
 from botocore.exceptions import ClientError

--- a/fogros2/fogros2/aws_cloud_instance.py
+++ b/fogros2/fogros2/aws_cloud_instance.py
@@ -115,24 +115,14 @@ class AWSCloudInstance(CloudInstance):
         self.generate_key_pair()
         self.create_ec2_instance()
         self.info(flush_to_disk=True)
-        self.test_latency()
-        # self.connect()
-        # self.install_ros()
-        # self.install_cloud_dependencies()
-        # self.install_colcon()
-        # self.push_ros_workspace()
-        # self.info(flush_to_disk=True)
-        # self._is_created = True
-
-    def test_latency(self):
-        ping_sum = 0
-        count = 0
-        while count < 100:
-            latency = ping(self._ip)
-            if latency:
-                ping_sum += latency
-                count += 1
-        print(ping_sum / count)
+        self.connect()
+        # Uncomment out the next three lines if you are not using a custom AMI
+        #self.install_ros()
+        #self.install_colcon()
+        #self.install_cloud_dependencies()
+        self.push_ros_workspace()
+        self.info(flush_to_disk=True)
+        self._is_created = True
 
     def info(self, flush_to_disk=True):
         info_dict = super().info(flush_to_disk)

--- a/fogros2/fogros2/aws_cloud_instance.py
+++ b/fogros2/fogros2/aws_cloud_instance.py
@@ -33,8 +33,6 @@
 
 import json
 import os
-import requests
-from math import radians, cos, sin, asin, sqrt
 from ping3 import ping
 
 import boto3
@@ -49,17 +47,19 @@ class AWSCloudInstance(CloudInstance):
 
     def __init__(
         self,
+        ami_image,
+        region="us-west-1",
         ec2_instance_type="t2.micro",
-        regions={},
         disk_size=30,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.cloud_service_provider = "AWS"
 
-        self.region, self.aws_ami_image = self.pick_region_and_ami(regions)
+        self.region = region
         self.ec2_instance_type = ec2_instance_type
         self.ec2_instance_disk_size = disk_size  # GB
+        self.aws_ami_image = ami_image
 
         # aws objects
         self.ec2_instance = None
@@ -108,47 +108,6 @@ class AWSCloudInstance(CloudInstance):
 
         self.create()
 
-    def pick_region_and_ami(self, regions):
-        aws_regions = {
-            "us-east-2": (40.4167, -82.9167),
-            "us-east-1": (38.0339, -78.4860),
-            "us-west-1": (37.7749, -122.4194),
-            "us-west-2": (45.5200, -122.6819),
-            "af-south-1": (-33.9249, 18.4241),
-            "ap-east-1": (22.2800, 114.1588),
-            "ap-southeast-3": (-6.2315, 106.8275),
-            "ap-south-1": (19.0760, 72.8777),
-            "ap-northeast-3": (34.6723, 135.4848),
-            "ap-northeast-2": (37.5665, 126.9780),
-            "ap-southeast-1": (1.3521, 103.8198),
-            "ap-southeast-2": (-33.8688, 151.2093),
-            "ap-northeast-1": (35.6895, 139.6917),
-            "ca-central-1": (43.6532, -79.3832),
-            "eu-central-1": (50.1147, 8.6821),
-            "eu-west-1": (53.4129, -8.2439),
-            "eu-west-2": (51.5074, -0.1278),
-            "eu-south-1": (45.4642, 9.1900),
-            "eu-west-3": (48.8566, 2.3522),
-            "eu-north-1": (59.3293, 18.0686),
-            "me-south-1": (26.0667, 50.5577),
-            "me-central-1": (23.4241, 53.8478),
-            "sa-east-1": (-23.5505, -46.6333),
-        }
-        ip = json.loads(requests.get("https://ip.seeip.org/jsonip?").text)["ip"]
-        response = requests.get("http://ip-api.com/json/" + ip).json()
-        lat = response["lat"]
-        long = response["lon"]
-        def haversine(lat1, lon1, lat2, lon2):
-            lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
-            dlon = lon2 - lon1 
-            dlat = lat2 - lat1 
-            a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
-            c = 2 * asin(sqrt(a)) 
-            km = 6371 * c
-            return km
-        closest_region = min(regions, key=lambda region: haversine(aws_regions[region][0], aws_regions[region][1], lat, long))
-        print(closest_region)
-        return closest_region, regions[closest_region]["ami_image"]
 
     def create(self):
         self.logger.info(f"Creating new EC2 instance with name {self._name}")

--- a/fogros2/fogros2/aws_cloud_instance.py
+++ b/fogros2/fogros2/aws_cloud_instance.py
@@ -33,6 +33,8 @@
 
 import json
 import os
+import requests
+from math import radians, cos, sin, asin, sqrt
 
 import boto3
 from botocore.exceptions import ClientError
@@ -46,19 +48,17 @@ class AWSCloudInstance(CloudInstance):
 
     def __init__(
         self,
-        ami_image,
-        region="us-west-1",
         ec2_instance_type="t2.micro",
+        regions={},
         disk_size=30,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.cloud_service_provider = "AWS"
 
-        self.region = region
+        self.region, self.aws_ami_image = self.pick_region_and_ami(regions)
         self.ec2_instance_type = ec2_instance_type
         self.ec2_instance_disk_size = disk_size  # GB
-        self.aws_ami_image = ami_image
 
         # aws objects
         self.ec2_instance = None
@@ -107,6 +107,48 @@ class AWSCloudInstance(CloudInstance):
 
         self.create()
 
+    def pick_region_and_ami(self, regions):
+        aws_regions = {
+            "us-east-2": (40.4167, -82.9167),
+            "us-east-1": (38.0339, -78.4860),
+            "us-west-1": (37.7749, -122.4194),
+            "us-west-2": (45.5200, -122.6819),
+            "af-south-1": (-33.9249, 18.4241),
+            "ap-east-1": (22.2800, 114.1588),
+            "ap-southeast-3": (-6.2315, 106.8275),
+            "ap-south-1": (19.0760, 72.8777),
+            "ap-northeast-3": (34.6723, 135.4848),
+            "ap-northeast-2": (37.5665, 126.9780),
+            "ap-southeast-1": (1.3521, 103.8198),
+            "ap-southeast-2": (-33.8688, 151.2093),
+            "ap-northeast-1": (35.6895, 139.6917),
+            "ca-central-1": (43.6532, -79.3832),
+            "eu-central-1": (50.1147, 8.6821),
+            "eu-west-1": (53.4129, -8.2439),
+            "eu-west-2": (51.5074, -0.1278),
+            "eu-south-1": (45.4642, 9.1900),
+            "eu-west-3": (48.8566, 2.3522),
+            "eu-north-1": (59.3293, 18.0686),
+            "me-south-1": (26.0667, 50.5577),
+            "me-central-1": (23.4241, 53.8478),
+            "sa-east-1": (-23.5505, -46.6333),
+        }
+        ip = json.loads(requests.get("https://ip.seeip.org/jsonip?").text)["ip"]
+        response = requests.get("https://geolocation-db.com/json/" + ip + "&position=true").json()
+        lat = response["latitude"]
+        long = response["longitude"]
+        def haversine(lat1, lon1, lat2, lon2):
+            lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
+            dlon = lon2 - lon1 
+            dlat = lat2 - lat1 
+            a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
+            c = 2 * asin(sqrt(a)) 
+            km = 6371 * c
+            return km
+        closest_region = min(regions, key=lambda region: haversine(aws_regions[region][0], aws_regions[region][1], lat, long))
+        print(closest_region)
+        return closest_region, regions[closest_region]["ami_image"]
+
     def create(self):
         self.logger.info(f"Creating new EC2 instance with name {self._name}")
         self.create_security_group()
@@ -115,8 +157,8 @@ class AWSCloudInstance(CloudInstance):
         self.info(flush_to_disk=True)
         self.connect()
         self.install_ros()
-        self.install_colcon()
         self.install_cloud_dependencies()
+        self.install_colcon()
         self.push_ros_workspace()
         self.info(flush_to_disk=True)
         self._is_created = True

--- a/fogros2/fogros2/aws_cloud_instance.py
+++ b/fogros2/fogros2/aws_cloud_instance.py
@@ -135,9 +135,9 @@ class AWSCloudInstance(CloudInstance):
             "sa-east-1": (-23.5505, -46.6333),
         }
         ip = json.loads(requests.get("https://ip.seeip.org/jsonip?").text)["ip"]
-        response = requests.get("https://geolocation-db.com/json/" + ip + "&position=true").json()
-        lat = response["latitude"]
-        long = response["longitude"]
+        response = requests.get("http://ip-api.com/json/" + ip).json()
+        lat = response["lat"]
+        long = response["lon"]
         def haversine(lat1, lon1, lat2, lon2):
             lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
             dlon = lon2 - lon1 

--- a/fogros2/fogros2/cloud_instance.py
+++ b/fogros2/fogros2/cloud_instance.py
@@ -128,6 +128,7 @@ class CloudInstance(abc.ABC):
         self.scp.execute_cmd(f"sudo pip3 install {args}")
 
     def install_cloud_dependencies(self):
+        self.scp.execute_cmd("sudo apt update")
         self.apt_install("wireguard unzip docker.io python3-pip")
 
     def install_ros(self):
@@ -159,7 +160,7 @@ class CloudInstance(abc.ABC):
         self.scp.execute_cmd("export LANG=en_US.UTF-8")
 
         # install ros2 packages
-        self.apt_install(f"ros-{self.ros_distro}-desktop")
+        # self.apt_install(f"ros-{self.ros_distro}-desktop")
 
         # source environment
         self.scp.execute_cmd(f"source /opt/ros/{self.ros_distro}/setup.bash")

--- a/fogros2/fogros2/cloud_instance.py
+++ b/fogros2/fogros2/cloud_instance.py
@@ -128,8 +128,7 @@ class CloudInstance(abc.ABC):
         self.scp.execute_cmd(f"sudo pip3 install {args}")
 
     def install_cloud_dependencies(self):
-        self.scp.execute_cmd("sudo apt update")
-        self.apt_install("wireguard unzip docker.io python3-pip")
+        self.apt_install("wireguard unzip docker.io python3-pip ros-humble-rmw-cyclonedds-cpp")
 
     def install_ros(self):
         # setup sources

--- a/fogros2/utils/ec2_instance_type_selection.py
+++ b/fogros2/utils/ec2_instance_type_selection.py
@@ -1,6 +1,7 @@
 import boto3
 import json
 from pkg_resources import resource_filename
+from .region_ami_selection import haversine, aws_regions
 
 FLT = '[{{"Field": "tenancy", "Value": "shared", "Type": "TERM_MATCH"}},'\
       '{{"Field": "operatingSystem", "Value": "{o}", "Type": "TERM_MATCH"}},'\
@@ -69,4 +70,6 @@ def ec2_instance_types(region_name, cpu_architecture="x86_64", default_cores=2, 
         describe_args['NextToken'] = describe_result['NextToken']
 
 def find_cheapest_ec2_instance_type(region_name, cpu_architecture="x86_64", default_cores=2, default_threads_per_core=1, gpu=False):
+    (lat, lon) = aws_regions[region_name]
+    region_name = min(['us-east-1', 'ap-south-1'], key= lambda region: haversine(region, lat, lon))
     return min(ec2_instance_types(region_name, cpu_architecture, default_cores, default_threads_per_core, gpu), key=lambda instance_type: get_price(region_name, instance_type, 'Linux'))

--- a/fogros2/utils/ec2_instance_type_selection.py
+++ b/fogros2/utils/ec2_instance_type_selection.py
@@ -1,0 +1,72 @@
+import boto3
+import json
+from pkg_resources import resource_filename
+
+FLT = '[{{"Field": "tenancy", "Value": "shared", "Type": "TERM_MATCH"}},'\
+      '{{"Field": "operatingSystem", "Value": "{o}", "Type": "TERM_MATCH"}},'\
+      '{{"Field": "preInstalledSw", "Value": "NA", "Type": "TERM_MATCH"}},'\
+      '{{"Field": "instanceType", "Value": "{t}", "Type": "TERM_MATCH"}},'\
+      '{{"Field": "location", "Value": "{r}", "Type": "TERM_MATCH"}},'\
+      '{{"Field": "capacitystatus", "Value": "Used", "Type": "TERM_MATCH"}}]'
+
+
+def get_price(region_name, instance, os):
+    f = FLT.format(r=get_region(region_name), t=instance, o=os)
+    pricing_client = boto3.client('pricing', 
+        region_name=region_name, 
+    )
+    data = pricing_client.get_products(ServiceCode='AmazonEC2', Filters=json.loads(f))
+    od = json.loads(data['PriceList'][0])['terms']['OnDemand']
+    id1 = list(od)[0]
+    id2 = list(od[id1]['priceDimensions'])[0]
+    price = od[id1]['priceDimensions'][id2]['pricePerUnit']['USD']
+    return price
+
+def get_region(region_name):
+    default_region = 'US East (N. Virginia)'
+    endpoint_file = resource_filename('botocore', 'data/endpoints.json')
+    try:
+        with open(endpoint_file, 'r') as f:
+            data = json.load(f)
+        return data['partitions'][0]['regions'][region_name]['description'].replace('Europe', 'EU')
+    except IOError:
+        return default_region
+
+def ec2_instance_types(region_name, cpu_architecture="x86_64", default_cores=2, default_threads_per_core=1, gpu=True):
+    '''Yield all available EC2 instance types in region <region_name>'''
+    ec2 = boto3.client('ec2', 
+        region_name=region_name,
+    )
+
+    describe_args = {
+        "Filters": [
+            {
+                'Name': 'processor-info.supported-architecture',
+                'Values': [
+                    cpu_architecture,
+                ]
+            },
+            {
+                'Name': 'vcpu-info.default-cores',
+                'Values': [
+                    str(default_cores),
+                ]
+            },
+            {
+                'Name': 'vcpu-info.default-threads-per-core',
+                'Values': [
+                    str(default_threads_per_core),
+                ]
+            },
+        ],
+    }
+
+    while True:
+        describe_result = ec2.describe_instance_types(**describe_args)
+        yield from [i["InstanceType"] for i in describe_result['InstanceTypes'] if not gpu or "GpuInfo" in i]
+        if 'NextToken' not in describe_result:
+            break
+        describe_args['NextToken'] = describe_result['NextToken']
+
+def find_cheapest_ec2_instance_type(region_name, cpu_architecture="x86_64", default_cores=2, default_threads_per_core=1, gpu=False):
+    return min(ec2_instance_types(region_name, cpu_architecture, default_cores, default_threads_per_core, gpu), key=lambda instance_type: get_price(region_name, instance_type, 'Linux'))

--- a/fogros2/utils/region_ami_selection.py
+++ b/fogros2/utils/region_ami_selection.py
@@ -1,0 +1,44 @@
+import json
+import requests
+from math import radians, cos, sin, asin, sqrt
+
+def find_nearest_region_and_ami(regions):
+        aws_regions = {
+            "us-east-2": (40.4167, -82.9167),
+            "us-east-1": (38.0339, -78.4860),
+            "us-west-1": (37.7749, -122.4194),
+            "us-west-2": (45.5200, -122.6819),
+            "af-south-1": (-33.9249, 18.4241),
+            "ap-east-1": (22.2800, 114.1588),
+            "ap-southeast-3": (-6.2315, 106.8275),
+            "ap-south-1": (19.0760, 72.8777),
+            "ap-northeast-3": (34.6723, 135.4848),
+            "ap-northeast-2": (37.5665, 126.9780),
+            "ap-southeast-1": (1.3521, 103.8198),
+            "ap-southeast-2": (-33.8688, 151.2093),
+            "ap-northeast-1": (35.6895, 139.6917),
+            "ca-central-1": (43.6532, -79.3832),
+            "eu-central-1": (50.1147, 8.6821),
+            "eu-west-1": (53.4129, -8.2439),
+            "eu-west-2": (51.5074, -0.1278),
+            "eu-south-1": (45.4642, 9.1900),
+            "eu-west-3": (48.8566, 2.3522),
+            "eu-north-1": (59.3293, 18.0686),
+            "me-south-1": (26.0667, 50.5577),
+            "me-central-1": (23.4241, 53.8478),
+            "sa-east-1": (-23.5505, -46.6333),
+        }
+        ip = json.loads(requests.get("https://ip.seeip.org/jsonip?").text)["ip"]
+        response = requests.get("http://ip-api.com/json/" + ip).json()
+        lat = response["lat"]
+        long = response["lon"]
+        def haversine(lat1, lon1, lat2, lon2):
+            lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
+            dlon = lon2 - lon1 
+            dlat = lat2 - lat1 
+            a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
+            c = 2 * asin(sqrt(a)) 
+            km = 6371 * c
+            return km
+        closest_region = min(regions, key=lambda region: haversine(aws_regions[region][0], aws_regions[region][1], lat, long))
+        return closest_region, regions[closest_region]["ami_image"]

--- a/fogros2/utils/region_ami_selection.py
+++ b/fogros2/utils/region_ami_selection.py
@@ -2,43 +2,45 @@ import json
 import requests
 from math import radians, cos, sin, asin, sqrt
 
+aws_regions = {
+    "us-east-2": (40.4167, -82.9167),
+    "us-east-1": (38.0339, -78.4860),
+    "us-west-1": (37.7749, -122.4194),
+    "us-west-2": (45.5200, -122.6819),
+    "af-south-1": (-33.9249, 18.4241),
+    "ap-east-1": (22.2800, 114.1588),
+    "ap-southeast-3": (-6.2315, 106.8275),
+    "ap-south-1": (19.0760, 72.8777),
+    "ap-northeast-3": (34.6723, 135.4848),
+    "ap-northeast-2": (37.5665, 126.9780),
+    "ap-southeast-1": (1.3521, 103.8198),
+    "ap-southeast-2": (-33.8688, 151.2093),
+    "ap-northeast-1": (35.6895, 139.6917),
+    "ca-central-1": (43.6532, -79.3832),
+    "eu-central-1": (50.1147, 8.6821),
+    "eu-west-1": (53.4129, -8.2439),
+    "eu-west-2": (51.5074, -0.1278),
+    "eu-south-1": (45.4642, 9.1900),
+    "eu-west-3": (48.8566, 2.3522),
+    "eu-north-1": (59.3293, 18.0686),
+    "me-south-1": (26.0667, 50.5577),
+    "me-central-1": (23.4241, 53.8478),
+    "sa-east-1": (-23.5505, -46.6333),
+}
+
 def find_nearest_region_and_ami(regions):
-        aws_regions = {
-            "us-east-2": (40.4167, -82.9167),
-            "us-east-1": (38.0339, -78.4860),
-            "us-west-1": (37.7749, -122.4194),
-            "us-west-2": (45.5200, -122.6819),
-            "af-south-1": (-33.9249, 18.4241),
-            "ap-east-1": (22.2800, 114.1588),
-            "ap-southeast-3": (-6.2315, 106.8275),
-            "ap-south-1": (19.0760, 72.8777),
-            "ap-northeast-3": (34.6723, 135.4848),
-            "ap-northeast-2": (37.5665, 126.9780),
-            "ap-southeast-1": (1.3521, 103.8198),
-            "ap-southeast-2": (-33.8688, 151.2093),
-            "ap-northeast-1": (35.6895, 139.6917),
-            "ca-central-1": (43.6532, -79.3832),
-            "eu-central-1": (50.1147, 8.6821),
-            "eu-west-1": (53.4129, -8.2439),
-            "eu-west-2": (51.5074, -0.1278),
-            "eu-south-1": (45.4642, 9.1900),
-            "eu-west-3": (48.8566, 2.3522),
-            "eu-north-1": (59.3293, 18.0686),
-            "me-south-1": (26.0667, 50.5577),
-            "me-central-1": (23.4241, 53.8478),
-            "sa-east-1": (-23.5505, -46.6333),
-        }
         ip = json.loads(requests.get("https://ip.seeip.org/jsonip?").text)["ip"]
         response = requests.get("http://ip-api.com/json/" + ip).json()
         lat = response["lat"]
         long = response["lon"]
-        def haversine(lat1, lon1, lat2, lon2):
-            lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
-            dlon = lon2 - lon1 
-            dlat = lat2 - lat1 
-            a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
-            c = 2 * asin(sqrt(a)) 
-            km = 6371 * c
-            return km
-        closest_region = min(regions, key=lambda region: haversine(aws_regions[region][0], aws_regions[region][1], lat, long))
+        closest_region = min(regions, key=lambda region: haversine(region, lat, long))
         return closest_region, regions[closest_region]["ami_image"]
+
+def haversine(region, lat, lon):
+    lon1, lat1, lon2, lat2 = map(radians, [aws_regions[region][1], aws_regions[region][0], lon, lat])
+    dlon = lon2 - lon1 
+    dlat = lat2 - lat1 
+    a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
+    c = 2 * asin(sqrt(a)) 
+    km = 6371 * c
+    return km

--- a/fogros2_examples/launch/talker.auto_aws.launch.py
+++ b/fogros2_examples/launch/talker.auto_aws.launch.py
@@ -1,0 +1,72 @@
+# Copyright 2022 The Regents of the University of California (Regents)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright ©2022. The Regents of the University of California (Regents).
+# All Rights Reserved. Permission to use, copy, modify, and distribute this
+# software and its documentation for educational, research, and not-for-profit
+# purposes, without fee and without a signed licensing agreement, is hereby
+# granted, provided that the above copyright notice, this paragraph and the
+# following two paragraphs appear in all copies, modifications, and
+# distributions. Contact The Office of Technology Licensing, UC Berkeley, 2150
+# Shattuck Avenue, Suite 510, Berkeley, CA 94720-1620, (510) 643-7201,
+# otl@berkeley.edu, http://ipira.berkeley.edu/industry-info for commercial
+# licensing opportunities. IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY
+# FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+# INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+# DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE. REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY,
+# PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+# MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+from launch_ros.actions import Node
+import fogros2
+from utils import region_ami_selection, ec2_instance_type_selection
+
+
+def generic_ubuntu_ami():
+    return {
+        "us-west-1": { "ami_image": "ami-01154c8b2e9a14885" },
+        "us-west-2": { "ami_image": "ami-0ddf424f81ddb0720" },
+        "us-east-1": { "ami_image": "ami-08d4ac5b634553e16" },
+        "us-east-2": { "ami_image": "ami-0960ab670c8bb45f3" },
+    }
+
+def generate_launch_description():
+    """Talker example that launches the listener on AWS."""
+    ld = fogros2.FogROSLaunchDescription()
+    
+    region, ami = region_ami_selection.find_nearest_region_and_ami(generic_ubuntu_ami())
+
+    ec2_instance_type = ec2_instance_type_selection.find_cheapest_ec2_instance_type(region)
+
+    print(region, ami, ec2_instance_type)
+    machine1 = fogros2.AWSCloudInstance(
+        region=region, ec2_instance_type=ec2_instance_type, ami_image=ami
+    )
+
+    listener_node = Node(
+        package="fogros2_examples", executable="listener", output="screen"
+    )
+
+    talker_node = fogros2.CloudNode(
+        package="fogros2_examples",
+        executable="talker",
+        output="screen",
+        machine=machine1,
+    )
+    ld.add_action(talker_node)
+    ld.add_action(listener_node)
+    return ld

--- a/fogros2_examples/launch/talker.aws.launch.py
+++ b/fogros2_examples/launch/talker.aws.launch.py
@@ -34,7 +34,6 @@
 from launch_ros.actions import Node
 
 import fogros2
-import time
 
 def ami_image():
     # An AMI is an Amazon Web Services virtual machine image with a
@@ -57,13 +56,11 @@ def generic_ubuntu_ami():
     return {
         # "us-west-1": { "ami_image": "ami-01154c8b2e9a14885" },
         # "us-west-2": { "ami_image": "ami-0ddf424f81ddb0720" },
-        "us-east-1": { "ami_image": "ami-08d4ac5b634553e16" },
-        # "us-east-2": { "ami_image": "ami-0960ab670c8bb45f3" },
+        # "us-east-1": { "ami_image": "ami-08d4ac5b634553e16" },
+        "us-east-2": { "ami_image": "ami-0960ab670c8bb45f3" },
     }
 
 def generate_launch_description():
-    start = time.time()
-    print("=========================================================================================")
     """Talker example that launches the listener on AWS."""
     ld = fogros2.FogROSLaunchDescription()
     machine1 = fogros2.AWSCloudInstance(
@@ -82,7 +79,4 @@ def generate_launch_description():
     )
     ld.add_action(talker_node)
     ld.add_action(listener_node)
-    print("=========================================================================================")
-    end = time.time()
-    print(end-start)
     return ld

--- a/fogros2_examples/launch/talker.aws.launch.py
+++ b/fogros2_examples/launch/talker.aws.launch.py
@@ -32,8 +32,8 @@
 # MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 from launch_ros.actions import Node
-
 import fogros2
+from utils import region_ami_selection, ec2_instance_type_selection
 
 def ami_image():
     # An AMI is an Amazon Web Services virtual machine image with a
@@ -63,8 +63,14 @@ def generic_ubuntu_ami():
 def generate_launch_description():
     """Talker example that launches the listener on AWS."""
     ld = fogros2.FogROSLaunchDescription()
+
+    region, ami = region_ami_selection.find_nearest_region_and_ami(generic_ubuntu_ami())
+
+    ec2_instance_type = ec2_instance_type_selection.find_cheapest_ec2_instance_type(region)
+
+    print(region, ami, ec2_instance_type)
     machine1 = fogros2.AWSCloudInstance(
-        ec2_instance_type="t2.micro", regions=generic_ubuntu_ami()
+        region=region, ec2_instance_type=ec2_instance_type, ami_image=ami
     )
 
     listener_node = Node(

--- a/fogros2_examples/launch/talker.aws.launch.py
+++ b/fogros2_examples/launch/talker.aws.launch.py
@@ -32,8 +32,9 @@
 # MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 from launch_ros.actions import Node
+
 import fogros2
-from utils import region_ami_selection, ec2_instance_type_selection
+
 
 def ami_image():
     # An AMI is an Amazon Web Services virtual machine image with a
@@ -48,29 +49,17 @@ def ami_image():
     if ubuntu_release == "20.04":
         return "ami-00f25057ddc9b310b"
     if ubuntu_release == "22.04":
-        return "ami-0b6030c78f8b2f076"
+        # "ami-034160df82745c454" is custom AMI
+        return "ami-034160df82745c454" #"ami-0b6030c78f8b2f076" 
 
     raise ValueError(f"No AMI for {ubuntu_release}")
 
-def generic_ubuntu_ami():
-    return {
-        "us-west-1": { "ami_image": "ami-01154c8b2e9a14885" },
-        "us-west-2": { "ami_image": "ami-0ddf424f81ddb0720" },
-        "us-east-1": { "ami_image": "ami-08d4ac5b634553e16" },
-        "us-east-2": { "ami_image": "ami-0960ab670c8bb45f3" },
-    }
 
 def generate_launch_description():
     """Talker example that launches the listener on AWS."""
     ld = fogros2.FogROSLaunchDescription()
-
-    region, ami = region_ami_selection.find_nearest_region_and_ami(generic_ubuntu_ami())
-
-    ec2_instance_type = ec2_instance_type_selection.find_cheapest_ec2_instance_type(region)
-
-    print(region, ami, ec2_instance_type)
     machine1 = fogros2.AWSCloudInstance(
-        region=region, ec2_instance_type=ec2_instance_type, ami_image=ami
+        region="us-west-1", ec2_instance_type="c5.4xlarge", ami_image=ami_image()
     )
 
     listener_node = Node(

--- a/fogros2_examples/launch/talker.aws.launch.py
+++ b/fogros2_examples/launch/talker.aws.launch.py
@@ -34,7 +34,7 @@
 from launch_ros.actions import Node
 
 import fogros2
-
+import time
 
 def ami_image():
     # An AMI is an Amazon Web Services virtual machine image with a
@@ -53,12 +53,21 @@ def ami_image():
 
     raise ValueError(f"No AMI for {ubuntu_release}")
 
+def generic_ubuntu_ami():
+    return {
+        # "us-west-1": { "ami_image": "ami-01154c8b2e9a14885" },
+        # "us-west-2": { "ami_image": "ami-0ddf424f81ddb0720" },
+        "us-east-1": { "ami_image": "ami-08d4ac5b634553e16" },
+        # "us-east-2": { "ami_image": "ami-0960ab670c8bb45f3" },
+    }
 
 def generate_launch_description():
+    start = time.time()
+    print("=========================================================================================")
     """Talker example that launches the listener on AWS."""
     ld = fogros2.FogROSLaunchDescription()
     machine1 = fogros2.AWSCloudInstance(
-        region="us-west-1", ec2_instance_type="t2.micro", ami_image=ami_image()
+        ec2_instance_type="t2.micro", regions=generic_ubuntu_ami()
     )
 
     listener_node = Node(
@@ -73,4 +82,7 @@ def generate_launch_description():
     )
     ld.add_action(talker_node)
     ld.add_action(listener_node)
+    print("=========================================================================================")
+    end = time.time()
+    print(end-start)
     return ld

--- a/fogros2_examples/launch/talker.aws.launch.py
+++ b/fogros2_examples/launch/talker.aws.launch.py
@@ -54,9 +54,9 @@ def ami_image():
 
 def generic_ubuntu_ami():
     return {
-        # "us-west-1": { "ami_image": "ami-01154c8b2e9a14885" },
-        # "us-west-2": { "ami_image": "ami-0ddf424f81ddb0720" },
-        # "us-east-1": { "ami_image": "ami-08d4ac5b634553e16" },
+        "us-west-1": { "ami_image": "ami-01154c8b2e9a14885" },
+        "us-west-2": { "ami_image": "ami-0ddf424f81ddb0720" },
+        "us-east-1": { "ami_image": "ami-08d4ac5b634553e16" },
         "us-east-2": { "ami_image": "ami-0960ab670c8bb45f3" },
     }
 


### PR DESCRIPTION
Have the scripts for datacenter selection and ec2 instance type selection in the utils folder in fogros2. Because boto3 pricing api only have endpoints in us-east-1 and ap-south-1, currently just checking to see which one is closer and using that region to get ec2 instance type pricing for comparison.